### PR TITLE
Feature/cache history pages

### DIFF
--- a/MinimedKit/MessageType.swift
+++ b/MinimedKit/MessageType.swift
@@ -29,6 +29,7 @@ public enum MessageType: UInt8 {
     case getPumpModel                 = 0x8d
     case readTempBasal                = 0x98
     case getGlucosePage               = 0x9A
+    case readCurrentPageNumber        = 0x9d
     case readSettings                 = 0xc0
     case readCurrentGlucosePage       = 0xcd
     case readPumpStatus               = 0xce
@@ -67,6 +68,8 @@ public enum MessageType: UInt8 {
             return ReadPumpStatusMessageBody.self
         case .readCurrentGlucosePage:
             return ReadCurrentGlucosePageMessageBody.self
+        case .readCurrentPageNumber:
+            return ReadCurrentPageNumberMessageBody.self
         case .getGlucosePage:
             return GetGlucosePageMessageBody.self
         default:

--- a/MinimedKit/Messages/ReadCurrentPageNumberMessageBody.swift
+++ b/MinimedKit/Messages/ReadCurrentPageNumberMessageBody.swift
@@ -8,15 +8,35 @@
 
 import Foundation
 
-class ReadCurrentPageNumberMessageBody : MessageBody {
-    static var length: Int = 30
+public class ReadCurrentPageNumberMessageBody : MessageBody {
+    public static var length: Int = 64
+    public let pageNum: Int
 
+    let rxData: Data
     
+    public var txData: Data {
+        return rxData
+    }
+ 
     public required init?(rxData: Data) {
-        return nil
+        
+        var page = 0
+        
+        if rxData.count > 1 {
+            page = Int(rxData[0])
+        }// else if rxData.count > 3 {
+//            page = Int(bigEndianBytes: rxData.subdata(in: 0..<4))
+//        }
+        
+        if page < 0 || page > 36 {
+            page = 36
+        }
+        
+        pageNum = page
+        self.rxData = rxData
     }
     
-    var txData: Data {
-        return Data()
-    }
+//    public var txData: Data {
+//        return Data()
+//    }
 }

--- a/MinimedKit/Messages/ReadCurrentPageNumberMessageBody.swift
+++ b/MinimedKit/Messages/ReadCurrentPageNumberMessageBody.swift
@@ -1,0 +1,22 @@
+//
+//  ReadCurrentPageNumberMessageBody.swift
+//  RileyLink
+//
+//  Created by Jaim Zuber on 2/17/17.
+//  Copyright © 2017 Pete Schwamb. All rights reserved.
+//
+
+import Foundation
+
+class ReadCurrentPageNumberMessageBody : MessageBody {
+    static var length: Int = 30
+
+    
+    public required init?(rxData: Data) {
+        return nil
+    }
+    
+    var txData: Data {
+        return Data()
+    }
+}

--- a/RileyLink.xcodeproj/project.pbxproj
+++ b/RileyLink.xcodeproj/project.pbxproj
@@ -334,6 +334,20 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
+		2F2440111E44F5460099DA7C /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = C12EA22F198B436800309FA4 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = C10D9BC01C8269D500378342;
+			remoteInfo = MinimedKit;
+		};
+		2F2440131E44F56D0099DA7C /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = C12EA22F198B436800309FA4 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 430D64CA1CB855AB00FCA750;
+			remoteInfo = RileyLinkBLEKit;
+		};
 		430D64D61CB855AB00FCA750 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = C12EA22F198B436800309FA4 /* Project object */;
@@ -1708,6 +1722,8 @@
 			buildRules = (
 			);
 			dependencies = (
+				2F2440141E44F56D0099DA7C /* PBXTargetDependency */,
+				2F2440121E44F5460099DA7C /* PBXTargetDependency */,
 				43C246A51D891DB80031F8D1 /* PBXTargetDependency */,
 			);
 			name = NightscoutUploadKit;
@@ -1772,9 +1788,11 @@
 						LastSwiftMigration = 0800;
 					};
 					C12EA236198B436800309FA4 = {
+						DevelopmentTeam = Y29J3QU5XB;
 						LastSwiftMigration = 0800;
 					};
 					C12EA251198B436800309FA4 = {
+						DevelopmentTeam = Y29J3QU5XB;
 						TestTargetID = C12EA236198B436800309FA4;
 					};
 					C1B3830A1CD0665D00CE7782 = {
@@ -2255,6 +2273,16 @@
 /* End PBXSourcesBuildPhase section */
 
 /* Begin PBXTargetDependency section */
+		2F2440121E44F5460099DA7C /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = C10D9BC01C8269D500378342 /* MinimedKit */;
+			targetProxy = 2F2440111E44F5460099DA7C /* PBXContainerItemProxy */;
+		};
+		2F2440141E44F56D0099DA7C /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 430D64CA1CB855AB00FCA750 /* RileyLinkBLEKit */;
+			targetProxy = 2F2440131E44F56D0099DA7C /* PBXContainerItemProxy */;
+		};
 		430D64D71CB855AB00FCA750 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			target = 430D64CA1CB855AB00FCA750 /* RileyLinkBLEKit */;
@@ -2772,10 +2800,10 @@
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
-				DEVELOPMENT_TEAM = "";
+				DEVELOPMENT_TEAM = Y29J3QU5XB;
 				INFOPLIST_FILE = "RileyLink/RileyLink-Info.plist";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
-				PRODUCT_BUNDLE_IDENTIFIER = com.rileylink.rlapp;
+				PRODUCT_BUNDLE_IDENTIFIER = com.sharpfive.rileylink.rlapp;
 				PRODUCT_NAME = RileyLink;
 				PROVISIONING_PROFILE = "";
 				SWIFT_OBJC_BRIDGING_HEADER = "RileyLink/RileyLink-Bridging-Header.h";
@@ -2793,10 +2821,10 @@
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
-				DEVELOPMENT_TEAM = "";
+				DEVELOPMENT_TEAM = Y29J3QU5XB;
 				INFOPLIST_FILE = "RileyLink/RileyLink-Info.plist";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
-				PRODUCT_BUNDLE_IDENTIFIER = com.rileylink.rlapp;
+				PRODUCT_BUNDLE_IDENTIFIER = com.sharpfive.rileylink.rlapp;
 				PRODUCT_NAME = RileyLink;
 				PROVISIONING_PROFILE = "";
 				SWIFT_OBJC_BRIDGING_HEADER = "RileyLink/RileyLink-Bridging-Header.h";
@@ -2811,7 +2839,7 @@
 				BUNDLE_LOADER = "$(BUILT_PRODUCTS_DIR)/RileyLink.app/RileyLink";
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				DEVELOPMENT_TEAM = "";
+				DEVELOPMENT_TEAM = Y29J3QU5XB;
 				GCC_PREPROCESSOR_DEFINITIONS = "$(inherited)";
 				INFOPLIST_FILE = "RileyLinkTests/RileyLinkTests-Info.plist";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
@@ -2829,7 +2857,7 @@
 				BUNDLE_LOADER = "$(BUILT_PRODUCTS_DIR)/RileyLink.app/RileyLink";
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				DEVELOPMENT_TEAM = "";
+				DEVELOPMENT_TEAM = Y29J3QU5XB;
 				INFOPLIST_FILE = "RileyLinkTests/RileyLinkTests-Info.plist";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.rileylink.${PRODUCT_NAME:rfc1034identifier}";

--- a/RileyLink.xcodeproj/project.pbxproj
+++ b/RileyLink.xcodeproj/project.pbxproj
@@ -8,6 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		2B19B9881DF3EF68006AB65F /* NewTimePumpEvent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2B19B9871DF3EF68006AB65F /* NewTimePumpEvent.swift */; };
+		2FDE1A071E57B12D00B56A27 /* ReadCurrentPageNumberMessageBody.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2FDE1A061E57B12D00B56A27 /* ReadCurrentPageNumberMessageBody.swift */; };
 		430D64CE1CB855AB00FCA750 /* RileyLinkBLEKit.h in Headers */ = {isa = PBXBuildFile; fileRef = 430D64CD1CB855AB00FCA750 /* RileyLinkBLEKit.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		430D64D51CB855AB00FCA750 /* RileyLinkBLEKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 430D64CB1CB855AB00FCA750 /* RileyLinkBLEKit.framework */; };
 		430D64DC1CB855AB00FCA750 /* RileyLinkBLEKitTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 430D64DB1CB855AB00FCA750 /* RileyLinkBLEKitTests.m */; };
@@ -464,6 +465,7 @@
 
 /* Begin PBXFileReference section */
 		2B19B9871DF3EF68006AB65F /* NewTimePumpEvent.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NewTimePumpEvent.swift; sourceTree = "<group>"; };
+		2FDE1A061E57B12D00B56A27 /* ReadCurrentPageNumberMessageBody.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ReadCurrentPageNumberMessageBody.swift; sourceTree = "<group>"; };
 		430D64CB1CB855AB00FCA750 /* RileyLinkBLEKit.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = RileyLinkBLEKit.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		430D64CD1CB855AB00FCA750 /* RileyLinkBLEKit.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = RileyLinkBLEKit.h; sourceTree = "<group>"; };
 		430D64CF1CB855AB00FCA750 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
@@ -1483,6 +1485,7 @@
 				43CA932C1CB8CFA1000026B5 /* ReadTempBasalCarelinkMessageBody.swift */,
 				43CA932D1CB8CFA1000026B5 /* ReadTimeCarelinkMessageBody.swift */,
 				C1EAD6C41C826B92006DBA60 /* UnknownMessageBody.swift */,
+				2FDE1A061E57B12D00B56A27 /* ReadCurrentPageNumberMessageBody.swift */,
 			);
 			path = Messages;
 			sourceTree = "<group>";
@@ -2103,6 +2106,7 @@
 				C1842BC31C8E931E00DB42AC /* BolusNormalPumpEvent.swift in Sources */,
 				541688DD1DB82213005B1891 /* ReadCurrentGlucosePageMessageBody.swift in Sources */,
 				43CA932F1CB8CFA1000026B5 /* ReadTimeCarelinkMessageBody.swift in Sources */,
+				2FDE1A071E57B12D00B56A27 /* ReadCurrentPageNumberMessageBody.swift in Sources */,
 				54BC44781DB46C7D00340EED /* GlucoseEvent.swift in Sources */,
 				546A85D01DF7BB8B00733213 /* SensorPacketGlucoseEvent.swift in Sources */,
 				C1842BFD1C8FA45100DB42AC /* ResumePumpEvent.swift in Sources */,

--- a/RileyLinkKit/PumpOpsSynchronous.swift
+++ b/RileyLinkKit/PumpOpsSynchronous.swift
@@ -514,7 +514,7 @@ class PumpOpsSynchronous {
             do {
                 let uintPageNum = UInt(pageNum)
                 
-                if let pageHistoryCache = pageHistoryCache {
+                if let pageHistoryCache = pageHistoryCache where pageNum > 0 {
                     
                     if let data = try pageHistoryCache.readFromCache(pageNumber: uintPageNum) {
                         pageData = data
@@ -554,7 +554,7 @@ class PumpOpsSynchronous {
                     if let date = timestamp.date?.addingTimeInterval(timeAdjustmentInterval) {
                         if date.timeIntervalSince(startDate) < -eventTimestampDeltaAllowance {
                             NSLog("Found event at (%@) to be more than %@s before startDate(%@)", date as NSDate, String(describing: eventTimestampDeltaAllowance), startDate as NSDate);
-                            break pages
+                            //break pages
                         } else if date.timeIntervalSince(timeCursor) > eventTimestampDeltaAllowance {
                             NSLog("Found event (%@) out of order in history. Ending history fetch.", date as NSDate)
                             break pages

--- a/RileyLinkKit/PumpOpsSynchronous.swift
+++ b/RileyLinkKit/PumpOpsSynchronous.swift
@@ -49,7 +49,7 @@ class PageHistoryCache : PageHistoryCacheable {
     func pageExists(pageNumber: UInt) -> Bool {
         let url = URLForPageNumber(pageNumber)
         
-        return fileManager.fileExists(atPath: url.absoluteString)
+        return fileManager.fileExists(atPath: url.path)
     }
     
     func cache(pageNumber: UInt, data: Data) throws {
@@ -68,6 +68,25 @@ class PageHistoryCache : PageHistoryCacheable {
         let data = try Data(contentsOf: url)
 
         return data
+    }
+    
+    func clearCache() -> Void {
+        
+        for pageNumber in 0..<16 {
+            let uintPageNumber = UInt(pageNumber)
+            
+            
+            if pageExists(pageNumber: uintPageNumber) {
+                
+                let url = URLForPageNumber(uintPageNumber)
+                do {
+                    try fileManager.removeItem(at: url)
+                } catch {
+                    
+                }
+            }
+            
+        }
     }
     
     private func URLForPageNumber(_ pageNumber: UInt) -> URL {

--- a/RileyLinkKit/PumpOpsSynchronous.swift
+++ b/RileyLinkKit/PumpOpsSynchronous.swift
@@ -282,10 +282,12 @@ class PumpOpsSynchronous {
         
         for attempt in 0..<3 {
             do {
-                _ = try sendAndListen(makePumpMessage(to: changeMessage.messageType))
+                let pumpMessage = try sendAndListen(makePumpMessage(to: changeMessage.messageType))
+                NSLog("pumpMessage:\(pumpMessage)")
                 
                 do {
-                    _ = try sendAndListen(changeMessage, retryCount: 0)
+                    let pumpMessage = try sendAndListen(changeMessage, retryCount: 0)
+                    NSLog("pumpMessage:\(pumpMessage)")
                 } catch {
                     // The pump does not ACK a temp basal. We'll check manually below if it was successful.
                 }
@@ -548,18 +550,18 @@ class PumpOpsSynchronous {
                     timestamp.timeZone = pump.timeZone
 
                     if let date = timestamp.date?.addingTimeInterval(timeAdjustmentInterval) {
-                        if date.timeIntervalSince(startDate) < -eventTimestampDeltaAllowance {
-                            NSLog("Found event at (%@) to be more than %@s before startDate(%@)", date as NSDate, String(describing: eventTimestampDeltaAllowance), startDate as NSDate);
-                            break pages
-                        } else if date.timeIntervalSince(timeCursor) > eventTimestampDeltaAllowance {
-                            NSLog("Found event (%@) out of order in history. Ending history fetch.", date as NSDate)
-                            break pages
-                        } else {
+//                        if date.timeIntervalSince(startDate) < -eventTimestampDeltaAllowance {
+//                            NSLog("Found event at (%@) to be more than %@s before startDate(%@)", date as NSDate, String(describing: eventTimestampDeltaAllowance), startDate as NSDate);
+//                            //break pages
+//                        } else if date.timeIntervalSince(timeCursor) > eventTimestampDeltaAllowance {
+//                            NSLog("Found event (%@) out of order in history. Ending history fetch.", date as NSDate)
+//                            //break pages
+//                        } else {
                             if (date.compare(startDate) != .orderedAscending) {
                                 timeCursor = date
                             }
                             events.insert(TimestampedHistoryEvent(pumpEvent: event, date: date), at: 0)
-                        }
+                        //}
                     }
                 }
 

--- a/RileyLinkKit/PumpOpsSynchronous.swift
+++ b/RileyLinkKit/PumpOpsSynchronous.swift
@@ -61,6 +61,10 @@ class PageHistoryCache : PageHistoryCacheable {
     func readFromCache(pageNumber: UInt) throws -> Data? {
         let url = URLForPageNumber(pageNumber)
         
+        if pageExists(pageNumber: pageNumber) == false {
+            return nil
+        }
+        
         let data = try Data(contentsOf: url)
 
         return data

--- a/RileyLinkKit/PumpOpsSynchronous.swift
+++ b/RileyLinkKit/PumpOpsSynchronous.swift
@@ -552,6 +552,10 @@ class PumpOpsSynchronous {
                 }
             }
             
+            NSLog("Done Fetching Page %d", pageNum)
+            let pageFetchTimeInterval = Date().timeIntervalSince(startPageFetch)
+            NSLog("Done Fetching Page timeElapsed \(pageFetchTimeInterval)")
+    
             var idx = 0
             let chunkSize = 256;
             while idx < pageData.count {
@@ -599,6 +603,9 @@ class PumpOpsSynchronous {
             }
         }
         NSLog("Returning %d events", events.count)
+        let timeElapsed = Date().timeIntervalSince(startCacheTime)
+        let timeElaspedString = "timeElapsed = \(timeElapsed)"
+        NSLog(timeElaspedString)
         return (events, pumpModel)
     }
     

--- a/RileyLinkKit/PumpOpsSynchronous.swift
+++ b/RileyLinkKit/PumpOpsSynchronous.swift
@@ -571,18 +571,18 @@ class PumpOpsSynchronous {
                     timestamp.timeZone = pump.timeZone
 
                     if let date = timestamp.date?.addingTimeInterval(timeAdjustmentInterval) {
-                        if date.timeIntervalSince(startDate) < -eventTimestampDeltaAllowance {
-                            NSLog("Found event at (%@) to be more than %@s before startDate(%@)", date as NSDate, String(describing: eventTimestampDeltaAllowance), startDate as NSDate);
-                            //break pages
-                        } else if date.timeIntervalSince(timeCursor) > eventTimestampDeltaAllowance {
-                            NSLog("Found event (%@) out of order in history. Ending history fetch.", date as NSDate)
-                            break pages
-                        } else {
+//                        if date.timeIntervalSince(startDate) < -eventTimestampDeltaAllowance {
+//                            NSLog("Found event at (%@) to be more than %@s before startDate(%@)", date as NSDate, String(describing: eventTimestampDeltaAllowance), startDate as NSDate);
+//                            //break pages
+//                        } else if date.timeIntervalSince(timeCursor) > eventTimestampDeltaAllowance {
+//                            NSLog("Found event (%@) out of order in history. Ending history fetch.", date as NSDate)
+//                            break pages
+//                        } else {
                             if (date.compare(startDate) != .orderedAscending) {
                                 timeCursor = date
                             }
                             events.insert(TimestampedHistoryEvent(pumpEvent: event, date: date), at: 0)
-                        }
+//                        }
                     }
                 }
 

--- a/RileyLinkKit/PumpOpsSynchronous.swift
+++ b/RileyLinkKit/PumpOpsSynchronous.swift
@@ -526,8 +526,13 @@ class PumpOpsSynchronous {
         var seenEventData = Set<Data>()
         var lastEvent: PumpEvent?
         
+        //pageHistoryCache?.clearCache()
+        
+        let startCacheTime = Date()
+        
         pages: for pageNum in 0..<16 {
             NSLog("Fetching page %d", pageNum)
+            let startPageFetch = Date()
             let pageData: Data
 
             do {

--- a/RileyLinkKit/PumpOpsSynchronous.swift
+++ b/RileyLinkKit/PumpOpsSynchronous.swift
@@ -286,12 +286,10 @@ class PumpOpsSynchronous {
         
         for attempt in 0..<3 {
             do {
-                let pumpMessage = try sendAndListen(makePumpMessage(to: changeMessage.messageType))
-                NSLog("pumpMessage:\(pumpMessage)")
+                _ = try sendAndListen(makePumpMessage(to: changeMessage.messageType))
                 
                 do {
-                    let pumpMessage = try sendAndListen(changeMessage, retryCount: 0)
-                    NSLog("pumpMessage:\(pumpMessage)")
+                    _ = try sendAndListen(changeMessage, retryCount: 0)
                 } catch {
                     // The pump does not ACK a temp basal. We'll check manually below if it was successful.
                 }
@@ -554,18 +552,18 @@ class PumpOpsSynchronous {
                     timestamp.timeZone = pump.timeZone
 
                     if let date = timestamp.date?.addingTimeInterval(timeAdjustmentInterval) {
-//                        if date.timeIntervalSince(startDate) < -eventTimestampDeltaAllowance {
-//                            NSLog("Found event at (%@) to be more than %@s before startDate(%@)", date as NSDate, String(describing: eventTimestampDeltaAllowance), startDate as NSDate);
-//                            //break pages
-//                        } else if date.timeIntervalSince(timeCursor) > eventTimestampDeltaAllowance {
-//                            NSLog("Found event (%@) out of order in history. Ending history fetch.", date as NSDate)
-//                            //break pages
-//                        } else {
+                        if date.timeIntervalSince(startDate) < -eventTimestampDeltaAllowance {
+                            NSLog("Found event at (%@) to be more than %@s before startDate(%@)", date as NSDate, String(describing: eventTimestampDeltaAllowance), startDate as NSDate);
+                            break pages
+                        } else if date.timeIntervalSince(timeCursor) > eventTimestampDeltaAllowance {
+                            NSLog("Found event (%@) out of order in history. Ending history fetch.", date as NSDate)
+                            break pages
+                        } else {
                             if (date.compare(startDate) != .orderedAscending) {
                                 timeCursor = date
                             }
                             events.insert(TimestampedHistoryEvent(pumpEvent: event, date: date), at: 0)
-                        //}
+                        }
                     }
                 }
 

--- a/RileyLinkKit/PumpOpsSynchronous.swift
+++ b/RileyLinkKit/PumpOpsSynchronous.swift
@@ -526,7 +526,11 @@ class PumpOpsSynchronous {
         var seenEventData = Set<Data>()
         var lastEvent: PumpEvent?
         
-        //pageHistoryCache?.clearCache()
+        let asdfData = Data()
+        
+        if let messageBody = ReadCurrentGlucosePageMessageBody(rxData: asdfData) {
+            let readPageNumberMessage = makePumpMessage(to: .readCurrentPageNumber, using: messageBody)
+        }
         
         let startCacheTime = Date()
         
@@ -538,7 +542,7 @@ class PumpOpsSynchronous {
             do {
                 let uintPageNum = UInt(pageNum)
                 
-                if let pageHistoryCache = pageHistoryCache where pageNum > 0 {
+                if let pageHistoryCache = pageHistoryCache, pageNum > 0 {
                     
                     if let data = try pageHistoryCache.readFromCache(pageNumber: uintPageNum) {
                         pageData = data


### PR DESCRIPTION
NOT FOR MERGE

This is a proof of concept for caching pages. Posted for review to get feedback on the basic concepts.

Note: Very rudimentary filesystem caching but enough to get the job done. I don't have strong opinions on how else to do it. Should it be integrated with the rest of the CoreData implementation?

PageHistoryCacheable protocol is designed to be injected so we can swap out the implementation.


@ps2 @loudnate 